### PR TITLE
Fix spill

### DIFF
--- a/asmcomp/deadcode.ml
+++ b/asmcomp/deadcode.ml
@@ -41,18 +41,18 @@ let rec deadcode i =
         assert (Array.length i.res > 0);  (* sanity check *)
         (s, before)
       end else begin
-        ({i with next = s}, Reg.add_set_array i.live arg)
+        (Mach.with_ i ~next:s, Reg.add_set_array i.live arg)
       end
   | Iifthenelse(test, ifso, ifnot) ->
       let (ifso', _) = deadcode ifso in
       let (ifnot', _) = deadcode ifnot in
       let (s, _) = deadcode i.next in
-      ({i with desc = Iifthenelse(test, ifso', ifnot'); next = s},
+      (Mach.with_ i ~desc:(Iifthenelse(test, ifso', ifnot')) ~next:s,
        Reg.add_set_array i.live arg)
   | Iswitch(index, cases) ->
       let cases' = Array.map (fun c -> fst (deadcode c)) cases in
       let (s, _) = deadcode i.next in
-      ({i with desc = Iswitch(index, cases'); next = s},
+      (Mach.with_ i ~desc:(Iswitch(index, cases')) ~next:s,
        Reg.add_set_array i.live arg)
   | Icatch(rec_flag, handlers, body) ->
       let (body', _) = deadcode body in
@@ -63,14 +63,14 @@ let rec deadcode i =
           handlers
       in
       let (s, _) = deadcode i.next in
-      ({i with desc = Icatch(rec_flag, handlers', body'); next = s}, i.live)
+      (Mach.with_ i ~desc:(Icatch(rec_flag, handlers', body')) ~next:s, i.live)
   | Iexit _nfail ->
       (i, i.live)
   | Itrywith(body, handler) ->
       let (body', _) = deadcode body in
       let (handler', _) = deadcode handler in
       let (s, _) = deadcode i.next in
-      ({i with desc = Itrywith(body', handler'); next = s}, i.live)
+      (Mach.with_ i ~desc:(Itrywith(body', handler')) ~next:s, i.live)
 
 let fundecl f =
   let (new_body, _) = deadcode f.fun_body in

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -176,3 +176,28 @@ let spacetime_node_hole_pointer_is_live_before insn =
     end
   | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Icatch _
   | Iexit _ | Itrywith _ | Iraise _ -> false
+
+let[@inline] with_ ?desc ?next ?arg ?res instr =
+  let desc =
+    match desc with
+    | None -> instr.desc
+    | Some desc -> desc
+  in
+  let next =
+    match next with
+    | None -> instr.next
+    | Some next -> next
+  in
+  let arg =
+    match arg with
+    | None -> instr.arg
+    | Some arg -> arg
+  in
+  let res =
+    match res with
+    | None -> instr.res
+    | Some res -> res
+  in
+  { instr with next; desc; arg; res }
+
+let[@inline] set_live instr live = instr.live <- live

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -66,7 +66,8 @@ type instruction =
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
-    mutable live: Reg.Set.t }
+    mutable live: Reg.Set.t;
+    id: int }
 
 and instruction_desc =
     Iend
@@ -101,7 +102,8 @@ let rec dummy_instr =
     arg = [||];
     res = [||];
     dbg = Debuginfo.none;
-    live = Reg.Set.empty }
+    live = Reg.Set.empty;
+    id = -1 }
 
 let end_instr () =
   { desc = Iend;
@@ -109,14 +111,21 @@ let end_instr () =
     arg = [||];
     res = [||];
     dbg = Debuginfo.none;
-    live = Reg.Set.empty }
+    live = Reg.Set.empty;
+    id = -2 }
+
+let next_id =
+  let count = ref 0 in
+  fun () -> incr count; !count
 
 let instr_cons d a r n =
   { desc = d; next = n; arg = a; res = r;
-    dbg = Debuginfo.none; live = Reg.Set.empty }
+    dbg = Debuginfo.none; live = Reg.Set.empty;
+    id = next_id () }
 
 let instr_cons_debug d a r dbg n =
-  { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty }
+  { desc = d; next = n; arg = a; res = r; dbg = dbg; live = Reg.Set.empty;
+    id = next_id () }
 
 let rec instr_iter f i =
   match i.desc with
@@ -198,6 +207,15 @@ let[@inline] with_ ?desc ?next ?arg ?res instr =
     | None -> instr.res
     | Some res -> res
   in
-  { instr with next; desc; arg; res }
+  { instr with next; desc; arg; res; id = next_id () }
 
 let[@inline] set_live instr live = instr.live <- live
+
+module Instruction = struct
+  module T = struct
+    type t = instruction
+    let compare i1 i2 =
+      compare i1.id i2.id
+  end
+  module Map = Map.Make(T)
+end

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -70,7 +70,7 @@ type operation =
   | Ifloatofint | Iintoffloat
   | Ispecific of Arch.specific_operation
 
-type instruction =
+type instruction = private
   { desc: instruction_desc;
     next: instruction;
     arg: Reg.t array;
@@ -122,3 +122,8 @@ val instr_cons_debug:
 val instr_iter: (instruction -> unit) -> instruction -> unit
 
 val spacetime_node_hole_pointer_is_live_before : instruction -> bool
+
+val with_:
+      ?desc:instruction_desc -> ?next:instruction -> ?arg:Reg.t array ->
+        ?res:Reg.t array -> instruction -> instruction
+val set_live: instruction -> Reg.Set.t -> unit

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -76,7 +76,8 @@ type instruction = private
     arg: Reg.t array;
     res: Reg.t array;
     dbg: Debuginfo.t;
-    mutable live: Reg.Set.t }
+    mutable live: Reg.Set.t;
+    id: int }
 
 and instruction_desc =
     Iend
@@ -127,3 +128,9 @@ val with_:
       ?desc:instruction_desc -> ?next:instruction -> ?arg:Reg.t array ->
         ?res:Reg.t array -> instruction -> instruction
 val set_live: instruction -> Reg.Set.t -> unit
+
+module Instruction : sig
+  module T : Map.OrderedType
+  module Map : Map.S with type key = instruction
+                      and type 'a t = 'a Map.Make(T).t
+end

--- a/asmcomp/reloadgen.ml
+++ b/asmcomp/reloadgen.ml
@@ -86,19 +86,19 @@ method private reload i =
   | Iop(Itailcall_ind _) ->
       let newarg = self#makereg1 i.arg in
       insert_moves i.arg newarg
-        {i with arg = newarg}
+        (Mach.with_ i ~arg:newarg)
   | Iop(Icall_imm _ | Iextcall _) ->
-      {i with next = self#reload i.next}
+      Mach.with_ i ~next:(self#reload i.next)
   | Iop(Icall_ind _) ->
       let newarg = self#makereg1 i.arg in
       insert_moves i.arg newarg
-        {i with arg = newarg; next = self#reload i.next}
+        (Mach.with_ i ~arg:newarg ~next:(self#reload i.next))
   | Iop op ->
       let (newarg, newres) = self#reload_operation op i.arg i.res in
       insert_moves i.arg newarg
-        {i with arg = newarg; res = newres; next =
-          (insert_moves newres i.res
-            (self#reload i.next))}
+        (Mach.with_ i ~arg:newarg ~res:newres
+           ~next:(insert_moves newres i.res
+                    (self#reload i.next)))
   | Iifthenelse(tst, ifso, ifnot) ->
       let newarg = self#reload_test tst i.arg in
       insert_moves i.arg newarg

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -556,7 +556,7 @@ method extract_core ~end_instr =
   let rec extract res i =
     if i == dummy_instr
     then res
-    else extract {i with next = res} i.next in
+    else extract (Mach.with_ i ~next:res) i.next in
   extract end_instr instr_seq
 
 method extract =

--- a/asmcomp/spill.ml
+++ b/asmcomp/spill.ml
@@ -204,11 +204,13 @@ let rec reload i before =
       let previous_reload_at_exit = !reload_at_exit in
       reload_at_exit := new_sets @ !reload_at_exit ;
       let (new_body, after_body) = reload body before in
+      let date_start = !current_date in
       let rec fixpoint () =
         let at_exits = List.map (fun (nfail, set) -> (nfail, !set)) new_sets in
         let res =
           List.map2 (fun (nfail', handler) (nfail, at_exit) ->
               assert(nfail = nfail');
+              current_date := date_start;
               reload handler at_exit) handlers at_exits in
         match rec_flag with
         | Cmm.Nonrecursive ->


### PR DESCRIPTION
There was nothing seriously broken, but nested loops with some ifs inside could produce large association lists. Going for a map is probably the simplest way to fix that.

I had to make instructions comparable. The previous equality being a physical equality, it had to be with a unique identifier. That led to adding an id field in Mach.instruction, which contains a fresh identifier, and make Mach.instruction private to ensure it is updated. The majority of the patch is the substitution from `{ i with next = something }` to `Mach.with_ i ~next:something`