### PR TITLE
Move generic call wrapping code into Emitaux

### DIFF
--- a/.depend
+++ b/.depend
@@ -842,6 +842,7 @@ typing/persistent_env.cmi : \
     typing/types.cmi \
     utils/misc.cmi \
     parsing/location.cmi \
+    utils/consistbl.cmi \
     typing/cmi_format.cmi
 typing/predef.cmo : \
     typing/types.cmi \
@@ -2999,6 +3000,10 @@ asmcomp/emit.cmi : \
     asmcomp/linearize.cmi \
     asmcomp/cmm.cmi
 asmcomp/emitaux.cmo : \
+    asmcomp/reg.cmi \
+    asmcomp/proc.cmi \
+    utils/misc.cmi \
+    asmcomp/mach.cmi \
     middle_end/debuginfo.cmi \
     utils/config.cmi \
     asmcomp/cmm.cmi \
@@ -3006,6 +3011,10 @@ asmcomp/emitaux.cmo : \
     asmcomp/arch.cmo \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmx : \
+    asmcomp/reg.cmx \
+    asmcomp/proc.cmx \
+    utils/misc.cmx \
+    asmcomp/mach.cmx \
     middle_end/debuginfo.cmx \
     utils/config.cmx \
     asmcomp/cmm.cmx \
@@ -3013,7 +3022,10 @@ asmcomp/emitaux.cmx : \
     asmcomp/arch.cmx \
     asmcomp/emitaux.cmi
 asmcomp/emitaux.cmi : \
-    middle_end/debuginfo.cmi
+    asmcomp/reg.cmi \
+    asmcomp/mach.cmi \
+    middle_end/debuginfo.cmi \
+    asmcomp/cmm.cmi
 asmcomp/export_info.cmo : \
     middle_end/base_types/variable.cmi \
     middle_end/base_types/var_within_closure.cmi \
@@ -5598,7 +5610,6 @@ driver/compplugin.cmo : \
     driver/compmisc.cmi \
     driver/compenv.cmi \
     driver/compdynlink.cmi \
-    utils/clflags.cmi \
     driver/compplugin.cmi
 driver/compplugin.cmx : \
     parsing/location.cmx \
@@ -5606,7 +5617,6 @@ driver/compplugin.cmx : \
     driver/compmisc.cmx \
     driver/compenv.cmx \
     driver/compdynlink.cmi \
-    utils/clflags.cmx \
     driver/compplugin.cmi
 driver/compplugin.cmi :
 driver/errors.cmo : \
@@ -6030,6 +6040,7 @@ toplevel/topdirs.cmo : \
     bytecomp/symtable.cmi \
     typing/printtyp.cmi \
     typing/predef.cmi \
+    typing/persistent_env.cmi \
     typing/path.cmi \
     parsing/parsetree.cmi \
     bytecomp/opcodes.cmi \
@@ -6042,7 +6053,6 @@ toplevel/topdirs.cmo : \
     typing/env.cmi \
     bytecomp/dll.cmi \
     typing/ctype.cmi \
-    utils/consistbl.cmi \
     utils/config.cmi \
     bytecomp/cmo_format.cmi \
     utils/clflags.cmi \
@@ -6059,6 +6069,7 @@ toplevel/topdirs.cmx : \
     bytecomp/symtable.cmx \
     typing/printtyp.cmx \
     typing/predef.cmx \
+    typing/persistent_env.cmx \
     typing/path.cmx \
     parsing/parsetree.cmi \
     bytecomp/opcodes.cmx \
@@ -6071,7 +6082,6 @@ toplevel/topdirs.cmx : \
     typing/env.cmx \
     bytecomp/dll.cmx \
     typing/ctype.cmx \
-    utils/consistbl.cmx \
     utils/config.cmx \
     bytecomp/cmo_format.cmi \
     utils/clflags.cmx \

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -82,6 +82,8 @@ let num_args_addressing = function
   | Iscaled _ -> 1
   | Iindexed2scaled _ -> 2
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -240,7 +240,7 @@ let record_frame =
 let wrap_call_with_frame ~call_labels call live raise_frame dbg =
   let frame_descr =
     Emitaux.mk_frame_descr
-      ~slot_offset ~label:call_labels.after ~frame_size:(frame_size ())
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
       ~live ~raise_frame ~dbg
   in
   Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
@@ -303,7 +303,9 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg ~spacetime =
   if !Clflags.debug || Config.spacetime then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame =
+      record_frame_label ?label ~live:Reg.Set.empty ~raise_frame:false ~dbg
+    in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error; bd_frame = lbl_frame;
         bd_spacetime = spacetime; } :: !bound_error_sites;
@@ -673,7 +675,8 @@ let emit_instr fallthrough i =
           else i.dbg
         in
         let lbl_frame =
-          record_frame_label ?label:label_after_call_gc i.live false dbg
+          record_frame_label ?label:label_after_call_gc ~live:i.live
+            ~raise_frame:false ~dbg
         in
         I.jb (label lbl_call_gc);
         I.lea (mem64 NONE 8 R15) (res i 0);
@@ -700,8 +703,8 @@ let emit_instr fallthrough i =
             emit_call "caml_allocN"
         end;
         let label =
-          record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+          record_frame_label ?label:label_after_call_gc ~live:i.live
+            ~raise_frame:false ~dbg:Debuginfo.none
         in
         def_label label;
         I.lea (mem64 NONE 8 R15) (res i 0)
@@ -896,7 +899,8 @@ let emit_instr fallthrough i =
       begin match k with
       | Cmm.Raise_withtrace ->
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          let label = Cmm.new_label () in
+          record_frame ~label ~live:Reg.Set.empty ~raise_frame:true ~dbg:i.dbg
       | Cmm.Raise_notrace ->
           I.mov r14 rsp;
           I.pop r14;

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -233,31 +233,20 @@ let addressing addr typ i n =
 
 (* Record live pointers at call points -- see Emitaux *)
 
-let record_frame_label ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
-  in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ()
-    )
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  lbl
+let record_frame_label = Emitaux.record_frame_label ~slot_offset ~frame_size
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
-  def_label lbl
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
+  in
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
+
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Spacetime instrumentation *)
 
@@ -490,23 +479,6 @@ let emit_profile () =
     I.pop r10
   end
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    _label (emit_label call_labels.before)
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    _label (emit_label call_labels.after)
-  end
-
 (* Output the assembly code for an instruction *)
 
 (* Name of current function *)
@@ -563,50 +535,49 @@ let emit_instr fallthrough i =
       add_used_symbol s;
       load_symbol_addr s (res i 0)
   | Lop(Icall_ind { call_labels; }) ->
-      maybe_add_label_before_call ~call_labels;
-      I.call (arg i 0);
-      record_frame i.live false i.dbg ~label:call_labels.after
+      wrap_call_with_frame ~call_labels
+        (fun () -> I.call (arg i 0))
+        i.live false i.dbg
   | Lop(Icall_imm { func; call_labels; }) ->
       add_used_symbol func;
-      maybe_add_label_before_call ~call_labels;
-      emit_call func;
-      record_frame i.live false i.dbg ~label:call_labels.after
+      wrap_call_with_frame ~call_labels
+        (fun () -> emit_call func)
+        i.live false i.dbg
   | Lop(Itailcall_ind { call_labels; }) ->
       output_epilogue begin fun () ->
-        maybe_add_label_before_call ~call_labels;
-        I.jmp (arg i 0);
+        let call () = I.jmp (arg i 0) in
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
+          wrap_call_with_frame ~call_labels call
+            Reg.Set.empty false i.dbg
         end else begin
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels call
         end
       end
   | Lop(Itailcall_imm { func; call_labels; }) ->
       if func = !function_name then begin
-        maybe_add_label_before_call ~call_labels;
-        I.jmp (label !tailrec_entry_point);
-        if not Config.spacetime then begin
-          maybe_add_label_after_call ~call_labels
-        end
+        let call () = I.jmp (label !tailrec_entry_point) in
+        if Config.spacetime then
+          wrap_call_with_frame ~call_labels call
+            Reg.Set.empty false i.dbg
+        else
+          wrap_call_no_frame ~call_labels call
       end else begin
         output_epilogue (fun () ->
           add_used_symbol func;
-          maybe_add_label_before_call ~call_labels;
-          emit_jump func;
-          if not Config.spacetime then begin
-            maybe_add_label_after_call ~call_labels
-          end)
-      end;
-      if Config.spacetime then begin
-        record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
+          let call () = emit_jump func in
+          if Config.spacetime then
+            wrap_call_with_frame ~call_labels call
+              Reg.Set.empty false i.dbg
+          else
+            wrap_call_no_frame ~call_labels call)
       end
   | Lop(Iextcall { func; alloc; call_labels; }) ->
       add_used_symbol func;
       if alloc then begin
         load_symbol_addr func rax;
-        maybe_add_label_before_call ~call_labels;
-        emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:call_labels.after;
+        wrap_call_with_frame ~call_labels
+          (fun () -> emit_call "caml_c_call")
+          i.live false i.dbg;
         if system <> S_win64 then begin
           (* TODO: investigate why such a diff.
              This comes from:
@@ -619,12 +590,12 @@ let emit_instr fallthrough i =
           I.mov (mem64 QWORD 0 R11) r15
         end
       end else begin
-        maybe_add_label_before_call ~call_labels;
-        emit_call func;
+        let call () = emit_call func in
         if Config.spacetime then begin
-          record_frame Reg.Set.empty false i.dbg ~label:call_labels.after
+          wrap_call_with_frame ~call_labels call
+            Reg.Set.empty false i.dbg
         end else begin
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels call
         end
       end
   | Lop(Istackoffset n) ->

--- a/asmcomp/arm/arch.ml
+++ b/asmcomp/arm/arch.ml
@@ -165,6 +165,8 @@ let offset_addressing (Iindexed n) delta = Iindexed(n + delta)
 
 let num_args_addressing (Iindexed _) = 1
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -99,29 +99,22 @@ let emit_addressing addr r n =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
-  in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  lbl
+let def_label lbl = `{emit_label lbl}:\n`
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in `{emit_label lbl}:`
+let record_frame_label = Emitaux.record_frame_label ~slot_offset ~frame_size
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
+
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
+  in
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
+
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -443,23 +436,6 @@ let emit_load_handler_address handler =
   `	add	lr, pc, lr\n`;
   2
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.before}:\n`
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.after}:\n`
-  end
-
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -553,56 +529,52 @@ let emit_instr i =
         emit_load_symbol_addr i.res.(0) s
     | Lop(Icall_ind { call_labels; }) ->
         if !arch >= ARMv5 then begin
-          maybe_add_label_before_call ~call_labels;
-          `	blx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 1
+          wrap_call_with_frame ~call_labels
+            (fun () -> `	blx	{emit_reg i.arg.(0)}\n`)
+            i.live false i.dbg; 1
         end else begin
           `	mov	lr, pc\n`;
-          maybe_add_label_before_call ~call_labels;
-          `	bx	{emit_reg i.arg.(0)}\n`;
-          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 2
+          wrap_call_with_frame ~call_labels
+            (fun () -> `	bx	{emit_reg i.arg.(0)}\n`)
+            i.live false i.dbg; 2
         end
     | Lop(Icall_imm { func; call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	{emit_call func}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`; 1
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	{emit_call func}\n`)
+          i.live false i.dbg; 1
     | Lop(Itailcall_ind { call_labels; }) ->
         output_epilogue begin fun () ->
           if !contains_calls then begin
             `	ldr	lr, [sp, #{emit_int (-4)}]\n`
           end;
-          maybe_add_label_before_call ~call_labels;
-          `	bx	{emit_reg i.arg.(0)}\n`;
-          maybe_add_label_after_call ~call_labels;
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	bx	{emit_reg i.arg.(0)}\n`);
           2
         end
     | Lop(Itailcall_imm { func; call_labels; }) ->
         if func = !function_name then begin
-          maybe_add_label_before_call ~call_labels;
-          `	b	{emit_label !tailrec_entry_point}\n`;
-          maybe_add_label_after_call ~call_labels;
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	b	{emit_label !tailrec_entry_point}\n`);
           1
         end else begin
           output_epilogue begin fun () ->
             if !contains_calls then begin
               `	ldr	lr, [sp, #{emit_int (-4)}]\n`
             end;
-            maybe_add_label_before_call ~call_labels;
-            `	{emit_jump func}\n`;
-            maybe_add_label_after_call ~call_labels;
+            wrap_call_no_frame ~call_labels
+              (fun () -> `	{emit_jump func}\n`);
             2
           end
         end
     | Lop(Iextcall { func; alloc = false; call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	{emit_call func}\n`;
-        maybe_add_label_after_call ~call_labels;
+        wrap_call_no_frame ~call_labels
+          (fun () -> `	{emit_call func}\n`);
         1
     | Lop(Iextcall { func; alloc = true; call_labels; }) ->
         let ninstr = emit_load_symbol_addr (phys_reg 7 (* r7 *)) func in
-        maybe_add_label_before_call ~call_labels;
-        `	{emit_call "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`;
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	{emit_call "caml_c_call"}\n`)
+          i.live false i.dbg;
         1 + ninstr
     | Lop(Istackoffset n) ->
         assert (n mod 8 = 0);

--- a/asmcomp/arm/emit.mlp
+++ b/asmcomp/arm/emit.mlp
@@ -108,7 +108,7 @@ let record_frame =
 let wrap_call_with_frame ~call_labels call live raise_frame dbg =
   let frame_descr =
     Emitaux.mk_frame_descr
-      ~slot_offset ~label:call_labels.after ~frame_size:(frame_size ())
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
       ~live ~raise_frame ~dbg
   in
   Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
@@ -142,7 +142,9 @@ let bound_error_sites = ref ([] : bound_error_call list)
 let bound_error_label ?label dbg =
   if !Clflags.debug || !bound_error_sites = [] then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame =
+      record_frame_label ?label ~live:Reg.Set.empty ~raise_frame:false ~dbg
+    in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error;
         bd_frame_lbl = lbl_frame } :: !bound_error_sites;
@@ -646,7 +648,8 @@ let emit_instr i =
         `	{emit_string instr}	{emit_reg r}, {emit_addressing addr i.arg 1}\n`; 1
     | Lop(Ialloc { bytes = n; label_after_call_gc; }) ->
         let lbl_frame =
-          record_frame_label i.live false i.dbg ?label:label_after_call_gc
+          record_frame_label ~live:i.live ~raise_frame:false ~dbg:i.dbg
+            ?label:label_after_call_gc
         in
         if !fastcode_flag then begin
           let lbl_redo = new_label() in
@@ -897,8 +900,9 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
+          let label = Cmm.new_label () in
           `	{emit_call "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`; 1
+          `{record_frame ~label ~live:Reg.Set.empty ~raise_frame:true ~dbg:i.dbg}\n`; 1
         | Cmm.Raise_notrace ->
           `	mov	sp, trap_ptr\n`;
           `	pop	\{trap_ptr, pc}\n`; 2

--- a/asmcomp/arm64/arch.ml
+++ b/asmcomp/arm64/arch.ml
@@ -93,6 +93,8 @@ let num_args_addressing = function
   | Iindexed _ -> 1
   | Ibased _ -> 0
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/arm64/emit.mlp
+++ b/asmcomp/arm64/emit.mlp
@@ -44,6 +44,9 @@ let reg_x15 = phys_reg 15
 let emit_label lbl =
   emit_string ".L"; emit_int lbl
 
+let def_label lbl =
+  `{emit_label lbl}:\n`
+
 (* Symbols *)
 
 let emit_symbol s =
@@ -117,31 +120,22 @@ let emit_addressing addr r =
       assert (not !Clflags.dlcode);  (* see selection.ml *)
       `[{emit_reg r}, #:lo12:{emit_symbol_offset s ofs}]`
 
-(* Record live pointers at call points *)
+(* Record live pointers at call points -- see Emitaux *)
 
-let record_frame_label ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
+let record_frame_label = Emitaux.record_frame_label ~slot_offset ~frame_size
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
+
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
   in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  lbl
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in `{emit_label lbl}:`
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -169,7 +163,9 @@ let bound_error_sites = ref ([] : bound_error_call list)
 let bound_error_label ?label dbg =
   if !Clflags.debug || !bound_error_sites = [] then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame =
+      record_frame_label ?label ~live:Reg.Set.empty ~raise_frame:false ~dbg
+    in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error;
         bd_frame_lbl = lbl_frame } :: !bound_error_sites;
@@ -522,7 +518,8 @@ end)
 
 let assembly_code_for_allocation ?label_after_call_gc i ~n ~far =
   let lbl_frame =
-    record_frame_label ?label:label_after_call_gc i.live false i.dbg
+    record_frame_label ?label:label_after_call_gc ~live:i.live
+      ~raise_frame:false ~dbg:i.dbg
   in
   if !fastcode_flag then begin
     let lbl_redo = new_label() in
@@ -570,23 +567,6 @@ let emit_profile() = ()   (* TODO *)
   | _ -> ()
 *)
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.before}:\n`
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.after}:\n`
-  end
-
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -633,38 +613,34 @@ let emit_instr i =
     | Lop(Iconst_symbol s) ->
         emit_load_symbol_addr i.res.(0) s
     | Lop(Icall_ind { call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	blr	{emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	blr	{emit_reg i.arg.(0)}\n`)
+          i.live false i.dbg
     | Lop(Icall_imm { func; call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	bl	{emit_symbol func}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	bl	{emit_symbol func}\n`)
+          i.live false i.dbg
     | Lop(Itailcall_ind { call_labels; }) ->
         output_epilogue (fun () ->
-          maybe_add_label_before_call ~call_labels;
-          `	br	{emit_reg i.arg.(0)}\n`;
-          maybe_add_label_after_call ~call_labels)
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	br	{emit_reg i.arg.(0)}\n`))
     | Lop(Itailcall_imm { func; call_labels; }) ->
         if func = !function_name then begin
-          maybe_add_label_before_call ~call_labels;
-          `	b	{emit_label !tailrec_entry_point}\n`;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	b	{emit_label !tailrec_entry_point}\n`)
         end else begin
           output_epilogue (fun () ->
-            maybe_add_label_before_call ~call_labels;
-            `	b	{emit_symbol func}\n`;
-            maybe_add_label_after_call ~call_labels)
+            wrap_call_no_frame ~call_labels
+              (fun () -> `	b	{emit_symbol func}\n`))
         end
     | Lop(Iextcall { func; alloc = false; call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	bl	{emit_symbol func}\n`;
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+          (fun () -> `	bl	{emit_symbol func}\n`)
     | Lop(Iextcall { func; alloc = true; call_labels; }) ->
         emit_load_symbol_addr reg_x15 func;
-        maybe_add_label_before_call ~call_labels;
-        `	bl	{emit_symbol "caml_c_call"}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	bl	{emit_symbol "caml_c_call"}\n`)
+          i.live false i.dbg
     | Lop(Istackoffset n) ->
         assert (n mod 16 = 0);
         emit_stack_adjustment (-n);
@@ -920,8 +896,9 @@ let emit_instr i =
     | Lraise k ->
         begin match k with
         | Cmm.Raise_withtrace ->
+          let label = Cmm.new_label () in
           `	bl	{emit_symbol "caml_raise_exn"}\n`;
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame ~label ~live:Reg.Set.empty ~raise_frame:true ~dbg:i.dbg}\n`
         | Cmm.Raise_notrace ->
           `	mov	sp, {emit_reg reg_trap_ptr}\n`;
           `	ldr	{emit_reg reg_tmp1}, [sp, #8]\n`;

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -114,13 +114,61 @@ type frame_descr =
 
 let frame_descriptors = ref([] : frame_descr list)
 
-let record_frame_descr ~label ~frame_size ~live_offset ~raise_frame debuginfo =
-  frame_descriptors :=
-    { fd_lbl = label;
-      fd_frame_size = frame_size;
-      fd_live_offset = List.sort_uniq (-) live_offset;
-      fd_raise = raise_frame;
-      fd_debuginfo = debuginfo } :: !frame_descriptors
+let record_frame_descr frame_descr =
+  frame_descriptors := frame_descr :: !frame_descriptors
+
+let mk_frame_descr ~slot_offset ~label ~frame_size ~live ~raise_frame ~dbg =
+  let live_offset = ref [] in
+  Reg.Set.iter
+    (function
+      | {Reg.typ = Cmm.Val; loc = Reg.Reg r} ->
+          live_offset := ((r lsl 1) + 1) :: !live_offset
+      | {Reg.typ = Cmm.Val; loc = Reg.Stack s} as reg ->
+          live_offset :=
+            slot_offset s (Proc.register_class reg) :: !live_offset
+      | {Reg.typ = Cmm.Addr} as r ->
+          Misc.fatal_error ("bad GC root " ^ Reg.name r)
+      | _ -> ()
+    )
+    live;
+  { fd_lbl = label;
+    fd_frame_size = frame_size;
+    fd_live_offset = List.sort_uniq (-) !live_offset;
+    fd_raise = raise_frame;
+    fd_debuginfo = dbg;
+  }
+
+let record_frame_label ~slot_offset ~frame_size ?label live raise_ dbg =
+  let lbl =
+    match label with
+    | None -> Cmm.new_label ()
+    | Some label -> label
+  in
+  let frame_descr =
+    mk_frame_descr ~slot_offset ~label:lbl ~frame_size:(frame_size ())
+      ~live ~raise_frame:raise_ ~dbg
+  in
+  record_frame_descr frame_descr;
+  lbl
+
+let record_frame ~slot_offset ~frame_size ~def_label
+    ?label live raise_ dbg =
+  let lbl =
+    record_frame_label ~slot_offset ~frame_size ?label live raise_ dbg
+  in
+  def_label lbl
+
+let wrap_call ~def_label call ?frame_descr ~call_labels =
+  let dcs = Arch.supports_dwarf_call_sites () in
+  if dcs then begin def_label call_labels.Mach.before end;
+  call ();
+  match frame_descr with
+  | None -> if dcs then begin def_label call_labels.Mach.after end
+  | Some f -> begin
+      def_label call_labels.Mach.after;
+      frame_descriptors :=
+        { f with fd_lbl = call_labels.Mach.after; } :: !frame_descriptors
+    end
 
 type emit_frame_actions =
   { efa_code_label: int -> unit;

--- a/asmcomp/emitaux.ml
+++ b/asmcomp/emitaux.ml
@@ -117,7 +117,7 @@ let frame_descriptors = ref([] : frame_descr list)
 let record_frame_descr frame_descr =
   frame_descriptors := frame_descr :: !frame_descriptors
 
-let mk_frame_descr ~slot_offset ~label ~frame_size ~live ~raise_frame ~dbg =
+let mk_frame_descr ~slot_offset ~return_label ~frame_size ~live ~raise_frame ~dbg =
   let live_offset = ref [] in
   Reg.Set.iter
     (function
@@ -131,30 +131,31 @@ let mk_frame_descr ~slot_offset ~label ~frame_size ~live ~raise_frame ~dbg =
       | _ -> ()
     )
     live;
-  { fd_lbl = label;
+  { fd_lbl = return_label;
     fd_frame_size = frame_size;
     fd_live_offset = List.sort_uniq (-) !live_offset;
     fd_raise = raise_frame;
     fd_debuginfo = dbg;
   }
 
-let record_frame_label ~slot_offset ~frame_size ?label live raise_ dbg =
+let record_frame_label ~slot_offset ~frame_size
+    ?label ~live ~raise_frame ~dbg =
   let lbl =
     match label with
     | None -> Cmm.new_label ()
     | Some label -> label
   in
   let frame_descr =
-    mk_frame_descr ~slot_offset ~label:lbl ~frame_size:(frame_size ())
-      ~live ~raise_frame:raise_ ~dbg
+    mk_frame_descr ~slot_offset ~return_label:lbl ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
   in
   record_frame_descr frame_descr;
   lbl
 
 let record_frame ~slot_offset ~frame_size ~def_label
-    ?label live raise_ dbg =
+    ?label ~live ~raise_frame ~dbg =
   let lbl =
-    record_frame_label ~slot_offset ~frame_size ?label live raise_ dbg
+    record_frame_label ~slot_offset ~frame_size ?label ~live ~raise_frame ~dbg
   in
   def_label lbl
 

--- a/asmcomp/emitaux.mli
+++ b/asmcomp/emitaux.mli
@@ -39,16 +39,17 @@ val emit_debug_info_gen :
   (file_num:int -> line:int -> col:int -> unit) -> unit
 
 type frame_descr
+
+(** Functions to compute stack offsets (in bytes) from stack locations *)
 type slot_offset := Reg.stack_location -> (* register class *) int -> int
 
 val mk_frame_descr :
   slot_offset : slot_offset ->
-                            (* Offsets from stack slots *)
-  label : Cmm.label ->      (* Return address *)
-  frame_size : int ->       (* Size of stack frame *)
-  live : Reg.Set.t ->       (* Live registers *)
-  raise_frame : bool ->     (* Is frame for a raise? *)
-  dbg : Debuginfo.t ->      (* Location, if any *)
+  return_label : Cmm.label ->
+  frame_size : int ->
+  live : Reg.Set.t ->
+  raise_frame : bool ->
+  dbg : Debuginfo.t ->
   frame_descr
 
 val record_frame_descr : frame_descr -> unit
@@ -57,9 +58,9 @@ val record_frame_label :
   slot_offset : slot_offset ->
   frame_size : (unit -> int) ->
   ?label : Cmm.label ->
-  Reg.Set.t ->              (* live *)
-  bool ->                   (* is_raise_frame *)
-  Debuginfo.t ->
+  live : Reg.Set.t ->
+  raise_frame : bool ->
+  dbg : Debuginfo.t ->
   Cmm.label
 
 val record_frame :
@@ -67,9 +68,9 @@ val record_frame :
   frame_size : (unit -> int) ->
   def_label : (Cmm.label -> unit) ->
   ?label : Cmm.label ->
-  Reg.Set.t ->              (* live *)
-  bool ->                   (* is_raise_frame *)
-  Debuginfo.t ->
+  live : Reg.Set.t ->
+  raise_frame : bool ->
+  dbg : Debuginfo.t ->
   unit
 
 val wrap_call :

--- a/asmcomp/i386/arch.ml
+++ b/asmcomp/i386/arch.ml
@@ -87,6 +87,8 @@ let num_args_addressing = function
   | Iscaled _ -> 1
   | Iindexed2scaled _ -> 2
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/i386/emit.mlp
+++ b/asmcomp/i386/emit.mlp
@@ -191,30 +191,20 @@ let addressing addr typ i n =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
-  in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  lbl
+let record_frame_label = Emitaux.record_frame_label ~slot_offset ~frame_size
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
-  def_label lbl
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
+  in
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
+
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Record calls to the GC -- we've moved them out of the way *)
 
@@ -245,7 +235,9 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg =
   if !Clflags.debug then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame =
+      record_frame_label ?label ~live:Reg.Set.empty ~raise_frame:false ~dbg
+    in
     bound_error_sites :=
       { bd_lbl = lbl_bound_error; bd_frame = lbl_frame } :: !bound_error_sites;
     lbl_bound_error
@@ -461,23 +453,6 @@ let emit_global_label s =
   D.global lbl;
   _label lbl
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    _label (emit_label call_labels.before)
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    _label (emit_label call_labels.after)
-  end
-
 (* Output the assembly code for an instruction *)
 
 (* Name of current function *)
@@ -555,44 +530,40 @@ let emit_instr fallthrough i =
       add_used_symbol s;
       I.mov (immsym s) (reg i.res.(0))
   | Lop(Icall_ind { call_labels; }) ->
-      maybe_add_label_before_call ~call_labels;
-      I.call (reg i.arg.(0));
-      record_frame i.live false i.dbg ~label:call_labels.after
+      wrap_call_with_frame ~call_labels
+        (fun () -> I.call (reg i.arg.(0)))
+        i.live false i.dbg
   | Lop(Icall_imm { func; call_labels; }) ->
       add_used_symbol func;
-      maybe_add_label_before_call ~call_labels;
-      emit_call func;
-      record_frame i.live false i.dbg ~label:call_labels.after
+      wrap_call_with_frame ~call_labels
+        (fun () -> emit_call func)
+        i.live false i.dbg
   | Lop(Itailcall_ind { call_labels; }) ->
       output_epilogue begin fun () ->
-        maybe_add_label_before_call ~call_labels;
-        I.jmp (reg i.arg.(0));
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+          (fun () -> I.jmp (reg i.arg.(0)))
       end
   | Lop(Itailcall_imm { func; call_labels; }) ->
       if func = !function_name then begin
-        maybe_add_label_before_call ~call_labels;
-        I.jmp (label !tailrec_entry_point);
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+        (fun () -> I.jmp (label !tailrec_entry_point))
       end else begin
         output_epilogue begin fun () ->
           add_used_symbol func;
-          maybe_add_label_before_call ~call_labels;
-          I.jmp (immsym func);
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            (fun () -> I.jmp (immsym func))
         end
       end
   | Lop(Iextcall { func; alloc; call_labels; }) ->
       add_used_symbol func;
       if alloc then begin
         I.mov (immsym func) eax;
-        maybe_add_label_before_call ~call_labels;
-        emit_call "caml_c_call";
-        record_frame i.live false i.dbg ~label:call_labels.after
+        wrap_call_with_frame ~call_labels
+          (fun () -> emit_call "caml_c_call")
+          i.live false i.dbg
       end else begin
-        maybe_add_label_before_call ~call_labels;
-        emit_call func;
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+          (fun () -> emit_call func)
       end
   | Lop(Istackoffset n) ->
       if n < 0
@@ -650,7 +621,9 @@ let emit_instr fallthrough i =
         I.mov eax (sym32 "caml_young_ptr");
         I.cmp (sym32 "caml_young_limit") eax;
         let lbl_call_gc = new_label() in
-        let lbl_frame = record_frame_label i.live false Debuginfo.none in
+        let lbl_frame = Cmm.new_label () in
+        record_frame ~label:lbl_frame ~live:i.live
+            ~raise_frame:false ~dbg:Debuginfo.none;
         I.jb (label lbl_call_gc);
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0));
         call_gc_sites :=
@@ -667,8 +640,8 @@ let emit_instr fallthrough i =
             emit_call "caml_allocN"
         end;
         let label =
-          record_frame_label ?label:label_after_call_gc i.live false
-            Debuginfo.none
+          record_frame_label ?label:label_after_call_gc ~live:i.live
+            ~raise_frame:false ~dbg:Debuginfo.none
         in
         def_label label;
         I.lea (mem32 NONE 4 RAX) (reg i.res.(0))
@@ -909,8 +882,9 @@ let emit_instr fallthrough i =
   | Lraise k  ->
       begin match k with
       | Cmm.Raise_withtrace ->
+          let label = Cmm.new_label () in
           emit_call "caml_raise_exn";
-          record_frame Reg.Set.empty true i.dbg
+          record_frame ~label ~live:Reg.Set.empty ~raise_frame:true ~dbg:i.dbg
       | Cmm.Raise_notrace ->
           I.mov (sym32 "caml_exception_pointer") esp;
           I.pop (sym32 "caml_exception_pointer");

--- a/asmcomp/power/arch.ml
+++ b/asmcomp/power/arch.ml
@@ -97,6 +97,8 @@ let num_args_addressing = function
   | Iindexed _ -> 1
   | Iindexed2 -> 2
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/power/emit.mlp
+++ b/asmcomp/power/emit.mlp
@@ -83,6 +83,9 @@ let label_prefix = ".L"
 let emit_label lbl =
   emit_string label_prefix; emit_int lbl
 
+let def_label lbl =
+  `{emit_label lbl}:\n`
+
 (* Section switching *)
 
 let code_space =
@@ -300,26 +303,19 @@ let adjust_stack_offset delta =
 
 (* Record live pointers at call points *)
 
-let record_frame ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
+
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
   in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := ((r lsl 1) + 1) :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  `{emit_label lbl}:\n`
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
+
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Record floating-point literals (for PPC32) *)
 
@@ -539,23 +535,6 @@ let emit_profile () =
       `	bl	{emit_symbol "caml_after_mcount"}\n`;
       `	mtlr	0\n`
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.before}:\n`
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.after}:\n`
-  end
-
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -652,31 +631,31 @@ let emit_instr i =
         begin match abi with
         | ELF32 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
-          maybe_add_label_before_call ~call_labels;
-          `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:call_labels.after
+          wrap_call_with_frame ~call_labels
+            (fun () -> `	bctrl\n`)
+            i.live false i.dbg
         | ELF64v1 ->
           `	ld	0, 0({emit_reg i.arg.(0)})\n`;  (* code pointer *)
           `	mtctr	0\n`;
           `	ld	2, 8({emit_reg i.arg.(0)})\n`;  (* TOC for callee *)
-          maybe_add_label_before_call ~call_labels;
-          `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:call_labels.after;
+          wrap_call_with_frame ~call_labels
+            (fun () -> `	bctrl\n`)
+            i.live false i.dbg;
           emit_reload_toc()
         | ELF64v2 ->
           `	mtctr	{emit_reg i.arg.(0)}\n`;
           `	mr	12, {emit_reg i.arg.(0)}\n`;  (* addr of fn in r12 *)
-          maybe_add_label_before_call ~call_labels;
-          `	bctrl\n`;
-          record_frame i.live false i.dbg ~label:call_labels.after;
+          wrap_call_with_frame ~call_labels
+            (fun () -> `	bctrl\n`)
+            i.live false i.dbg;
           emit_reload_toc()
         end
     | Lop(Icall_imm { func; call_labels; }) ->
         begin match abi with
         | ELF32 ->
-            maybe_add_label_before_call ~call_labels;
-            emit_call func;
-            record_frame i.live false i.dbg ~label:call_labels.after
+            wrap_call_with_frame ~call_labels
+              (fun () -> emit_call func)
+              i.live false i.dbg
         | ELF64v1 | ELF64v2 ->
         (* For PPC64, we cannot just emit a "bl s; nop" sequence, because
            of the following scenario:
@@ -695,9 +674,9 @@ let emit_instr i =
                 by the linker, but this is harmless.
                 Cost: 3 instructions if same TOC, 7 if different TOC.
            Let's try option 2. *)
-            maybe_add_label_before_call ~call_labels;
-            emit_call func;
-            record_frame i.live false i.dbg ~label:call_labels.after;
+            wrap_call_with_frame ~call_labels
+              (fun () -> emit_call func)
+              i.live false i.dbg;
             `	nop\n`;
             emit_reload_toc()
         end
@@ -718,14 +697,12 @@ let emit_instr i =
           `	mtlr	11\n`
         end;
         emit_free_frame();
-        maybe_add_label_before_call ~call_labels;
-        `	bctr\n`;
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+          (fun () -> `	bctr\n`)
     | Lop(Itailcall_imm { func; call_labels; }) ->
         if func = !function_name then begin
-          maybe_add_label_before_call ~call_labels;
-          `	b	{emit_label !tailrec_entry_point}\n`;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	b	{emit_label !tailrec_entry_point}\n`)
         end else begin
           begin match abi with
           | ELF32 ->
@@ -744,34 +721,33 @@ let emit_instr i =
             `	mtlr	11\n`
           end;
           emit_free_frame();
-          maybe_add_label_before_call ~call_labels;
-          begin match abi with
-          | ELF32 ->
-            `	b	{emit_symbol func}\n`
-          | ELF64v1 | ELF64v2 ->
-            `	bctr\n`
-          end;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            begin fun () ->
+              match abi with
+              | ELF32 ->
+                `	b	{emit_symbol func}\n`
+              | ELF64v1 | ELF64v2 ->
+                `	bctr\n`
+            end
         end
     | Lop(Iextcall { func; alloc; call_labels; }) ->
         if not alloc then begin
-          maybe_add_label_before_call ~call_labels;
-          emit_call func;
-          maybe_add_label_after_call ~call_labels;
+          wrap_call_no_frame ~call_labels
+            (fun () -> emit_call func);
           emit_call_nop()
         end else begin
           match abi with
           | ELF32 ->
             `	addis	28, 0, {emit_upper emit_symbol func}\n`;
             `	addi	28, 28, {emit_lower emit_symbol func}\n`;
-            maybe_add_label_before_call ~call_labels;
-            emit_call "caml_c_call";
-            record_frame i.live false i.dbg
+            wrap_call_with_frame ~call_labels
+              (fun () -> emit_call "caml_c_call")
+              i.live false i.dbg
           | ELF64v1 | ELF64v2 ->
             emit_tocload emit_gpr 28 (TocSym func);
-            maybe_add_label_before_call ~call_labels;
-            emit_call "caml_c_call";
-            record_frame i.live false i.dbg;
+            wrap_call_with_frame ~call_labels
+              (fun () -> emit_call "caml_c_call")
+              i.live false i.dbg;
             `	nop\n`
         end
     | Lop(Istackoffset n) ->
@@ -813,7 +789,8 @@ let emit_instr i =
         `	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`;
         `	bltl	{emit_label !call_gc_label}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none
+        record_frame ?label:None ~live:i.live
+          ~raise_frame:false ~dbg:Debuginfo.none
     | Lop(Ispecific(Ialloc_far { bytes = n; label_after_call_gc; })) ->
         if !call_gc_label = 0 then begin
           match label_after_call_gc with
@@ -826,7 +803,8 @@ let emit_instr i =
         `	bge	{emit_label lbl}\n`;
         `	bl	{emit_label !call_gc_label}\n`;
         (* Exactly 4 instructions after the beginning of the alloc sequence *)
-        record_frame i.live false Debuginfo.none;
+        record_frame ?label:None ~live:i.live
+          ~raise_frame:false ~dbg:Debuginfo.none;
         `{emit_label lbl}:	addi	{emit_reg i.res.(0)}, 31, {emit_int size_addr}\n`
     | Lop(Iintop Isub) ->               (* subfc has swapped arguments *)
         `	subfc	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
@@ -845,7 +823,8 @@ let emit_instr i =
         end
     | Lop(Iintop (Icheckbound { label_after_error; })) ->
         if !Clflags.debug then
-          record_frame Reg.Set.empty false i.dbg ?label:label_after_error;
+          record_frame ~live:Reg.Set.empty ~raise_frame:false
+            ~dbg:i.dbg ?label:label_after_error;
         `	{emit_string tglle}   {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
     | Lop(Iintop op) ->
         let instr = name_for_intop op in
@@ -863,7 +842,8 @@ let emit_instr i =
         end
     | Lop(Iintop_imm(Icheckbound { label_after_error; }, n)) ->
         if !Clflags.debug then
-          record_frame Reg.Set.empty false i.dbg ?label:label_after_error;
+          record_frame ~live:Reg.Set.empty ~raise_frame:false
+            ~dbg:i.dbg ?label:label_after_error;
         `	{emit_string tglle}i   {emit_reg i.arg.(0)}, {emit_int n}\n`
     | Lop(Iintop_imm(op, n)) ->
         let instr = name_for_intop_imm op in
@@ -1037,7 +1017,8 @@ let emit_instr i =
         begin match k with
         | Cmm.Raise_withtrace ->
             emit_call "caml_raise_exn";
-            record_frame Reg.Set.empty true i.dbg;
+            record_frame ?label:None ~live:Reg.Set.empty
+              ~raise_frame:true ~dbg:i.dbg;
             emit_call_nop()
         | Cmm.Raise_notrace ->
             `	{emit_string lg}	0, {emit_int trap_handler_offset}(29)\n`;

--- a/asmcomp/s390x/arch.ml
+++ b/asmcomp/s390x/arch.ml
@@ -70,6 +70,8 @@ let num_args_addressing = function
   | Iindexed _ -> 1
   | Iindexed2 _ -> 2
 
+let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
+
 (* Printing operations and addressing modes *)
 
 let print_addressing printreg addr ppf arg =

--- a/asmcomp/s390x/emit.mlp
+++ b/asmcomp/s390x/emit.mlp
@@ -65,6 +65,9 @@ let label_prefix = ".L"
 let emit_label lbl =
   emit_string label_prefix; emit_int lbl
 
+let def_label lbl =
+  `{emit_label lbl}:\n`
+
 (* Section switching *)
 
 let data_space = "	.section \".data\"\n"
@@ -162,30 +165,20 @@ let emit_set_comp cmp res =
 
 (* Record live pointers at call points *)
 
-let record_frame_label ?label live raise_ dbg =
-  let lbl =
-    match label with
-    | None -> new_label()
-    | Some label -> label
-  in
-  let live_offset = ref [] in
-  Reg.Set.iter
-    (function
-      | {typ = Val; loc = Reg r} ->
-          live_offset := (r lsl 1) + 1 :: !live_offset
-      | {typ = Val; loc = Stack s} as reg ->
-          live_offset := slot_offset s (register_class reg) :: !live_offset
-      | {typ = Addr} as r ->
-          Misc.fatal_error ("bad GC root " ^ Reg.name r)
-      | _ -> ())
-    live;
-  record_frame_descr ~label:lbl ~frame_size:(frame_size())
-    ~live_offset:!live_offset ~raise_frame:raise_ dbg;
-  lbl
+let record_frame_label = Emitaux.record_frame_label ~slot_offset ~frame_size
+let record_frame =
+  Emitaux.record_frame ~slot_offset ~frame_size ~def_label
 
-let record_frame ?label live raise_ dbg =
-  let lbl = record_frame_label ?label live raise_ dbg in
-  `{emit_label lbl}:`
+let wrap_call_with_frame ~call_labels call live raise_frame dbg =
+  let frame_descr =
+    Emitaux.mk_frame_descr
+      ~slot_offset ~return_label:call_labels.after ~frame_size:(frame_size ())
+      ~live ~raise_frame ~dbg
+  in
+  Emitaux.wrap_call ~def_label call ~frame_descr ~call_labels
+
+let wrap_call_no_frame ~call_labels call =
+  Emitaux.wrap_call ~def_label call ?frame_descr:None ~call_labels
 
 (* Record calls to caml_call_gc, emitted out of line. *)
 
@@ -212,7 +205,8 @@ let bound_error_call = ref 0
 let bound_error_label ?label dbg =
   if !Clflags.debug then begin
     let lbl_bound_error = new_label() in
-    let lbl_frame = record_frame_label ?label Reg.Set.empty false dbg in
+    let lbl_frame = record_frame_label ?label ~live:Reg.Set.empty
+        ~raise_frame:false ~dbg in
     bound_error_sites :=
      { bd_lbl = lbl_bound_error; bd_frame = lbl_frame } :: !bound_error_sites;
    lbl_bound_error
@@ -301,23 +295,6 @@ let function_name = ref ""
 (* Entry point for tail recursive calls *)
 let tailrec_entry_point = ref 0
 
-(* Emission of labels immediately prior to and after calls, used for DWARF
-   call site support. *)
-
-let supports_dwarf_call_sites () = false  (* To be filled in by a later GPR. *)
-
-let maybe_add_label_before_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.before}:\n`
-  end
-
-(* This function should not be called if [record_frame] is going to be used,
-   since the latter defines the same label as this function. *)
-let maybe_add_label_after_call ~call_labels =
-  if supports_dwarf_call_sites () then begin
-    `{emit_label call_labels.after}:\n`
-  end
-
 (* Output the assembly code for an instruction *)
 
 let emit_instr i =
@@ -367,53 +344,51 @@ let emit_instr i =
      | Lop(Iconst_symbol s) ->
         emit_load_symbol_addr i.res.(0) s
     | Lop(Icall_ind { call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        `	basr	%r14, {emit_reg i.arg.(0)}\n`;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+        wrap_call_with_frame ~call_labels
+          (fun () -> `	basr	%r14, {emit_reg i.arg.(0)}\n`)
+          i.live false i.dbg
 
     | Lop(Icall_imm { func; call_labels; }) ->
-        maybe_add_label_before_call ~call_labels;
-        emit_call func;
-        `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+        wrap_call_with_frame ~call_labels
+          (fun () -> emit_call func)
+          i.live false i.dbg
     | Lop(Itailcall_ind { call_labels; }) ->
         let n = frame_size() in
         if !contains_calls then begin
           `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`
         end;
         emit_stack_adjust (-n);
-        maybe_add_label_before_call ~call_labels;
-        `	br	{emit_reg i.arg.(0)}\n`;
-        maybe_add_label_after_call ~call_labels
+        wrap_call_no_frame ~call_labels
+          (fun () -> `	br	{emit_reg i.arg.(0)}\n`)
     | Lop(Itailcall_imm { func; call_labels; }) ->
         if func = !function_name then begin
-          maybe_add_label_before_call ~call_labels;
-          `	brcl	15, {emit_label !tailrec_entry_point}\n`;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            (fun () -> `	brcl	15, {emit_label !tailrec_entry_point}\n`)
         end else begin
           let n = frame_size() in
           if !contains_calls then begin
             `	lg	%r14, {emit_int(n - size_addr)}(%r15)\n`
           end;
           emit_stack_adjust (-n);
-          maybe_add_label_before_call ~call_labels;
-          if !pic_code then begin
-            `	brcl	15, {emit_symbol func}@PLT\n`
-          end else begin
-            `	brcl	15, {emit_symbol func}\n`
-          end;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            begin fun () ->
+              if !pic_code then begin
+                `	brcl	15, {emit_symbol func}@PLT\n`
+              end else begin
+                `	brcl	15, {emit_symbol func}\n`
+              end
+            end
         end
 
      | Lop(Iextcall { func; alloc; call_labels; }) ->
         if not alloc then begin
-          maybe_add_label_before_call ~call_labels;
-          emit_call func;
-          maybe_add_label_after_call ~call_labels
+          wrap_call_no_frame ~call_labels
+            (fun () -> emit_call func)
         end else begin
           emit_load_symbol_addr reg_r7 func;
-          maybe_add_label_before_call ~call_labels;
-          emit_call "caml_c_call";
-          `{record_frame i.live false i.dbg ~label:call_labels.after}\n`
+          wrap_call_with_frame ~call_labels
+            (fun () -> emit_call "caml_c_call")
+            i.live false i.dbg
         end
 
      | Lop(Istackoffset n) ->
@@ -454,7 +429,8 @@ let emit_instr i =
         let lbl_redo = new_label() in
         let lbl_call_gc = new_label() in
         let lbl_frame =
-          record_frame_label i.live false i.dbg ?label:label_after_call_gc
+          record_frame_label ~live:i.live ~raise_frame:false ~dbg:i.dbg
+            ?label:label_after_call_gc
         in
         call_gc_sites :=
           { gc_lbl = lbl_call_gc;
@@ -657,7 +633,7 @@ let emit_instr i =
         begin match k with
         | Cmm.Raise_withtrace ->
           emit_call "caml_raise_exn";
-          `{record_frame Reg.Set.empty true i.dbg}\n`
+          `{record_frame ?label:None ~live:Reg.Set.empty ~raise_frame:true ~dbg:i.dbg}\n`
         | Cmm.Raise_notrace ->
           `	lg	%r1, 0(%r13)\n`;
           `	lgr	%r15, %r13\n`;


### PR DESCRIPTION
If you're fine with the changes to `Emitaux` and amd64, I'll update the other architectures too.