### PR TITLE
Adapt un_cps to SOC update

### DIFF
--- a/middle_end/flambda2.0/flambda2_middle_end.ml
+++ b/middle_end/flambda2.0/flambda2_middle_end.ml
@@ -108,7 +108,6 @@ let middle_end0 ppf ~prefixname:_ ~backend ~size ~filename
     print_flambda "simplify" ppf flambda;
     let flambda = Remove_unused_closure_vars.run flambda in
     print_flambda "remove_unused_closure_vars" ppf flambda;
-    let _ = exit 0 in  (* XXX Remove once [Un_cps] is fixed *)
     flambda)
 
 let middle_end ~ppf_dump:ppf ~prefixname ~backend ~size ~filename ~module_ident


### PR DESCRIPTION
The fix involves basically compiling the `Set_of_closures` version of `Let` into the closure block creation followed by let binding all the closure variables to their projections.
For static sets of closures, I have not created a symbol for the whole block, assuming that the block is never updated (which was the only use of the symbol except for exporting).

CC @Gbury who may want to look at the patch at some point