### PR TITLE
Bugfixes

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
@@ -665,15 +665,21 @@ let compute_offsets program =
 (* Map on each function body once.
    This is useful to avoid a global state of translated function bodies *)
 
+
+(* CR Gbury: currently closure_name and closure_id_name **must** be in sync
+             (which is manual task somewhat complex). It would be better to
+             have a unique mapping from closure_id to linkage name somewhere. *)
 let closure_name id =
   let compunit = Closure_id.get_compilation_unit id in
   let name = Compilation_unit.get_linkage_name compunit in
-  Format.asprintf "%a_%s" Linkage_name.print name (Closure_id.unique_name id)
+  Format.asprintf "%a__%s" Linkage_name.print name (Closure_id.unique_name id)
 
 let closure_id_name o id =
   match o with
   | None -> closure_name id
   | Some map ->
+      (* CR Gbury: is this part really necessary ? why not always
+                   return closure_name id ? *)
       let s = Closure_id.Map.find id map in
       let name = Symbol.linkage_name s in
       Format.asprintf "%a" Linkage_name.print name

--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
@@ -311,9 +311,16 @@ module Greedy = struct
     | Closure _ -> true
     | Env_var _ -> false
 
+  let add_slot_offset_to_set offset slot set =
+    let map = set.allocated_slots in
+    assert (not (Numbers.Int.Map.mem offset map));
+    let map = Numbers.Int.Map.add offset slot map in
+    set.allocated_slots <- map
+
   let add_slot_offset env slot offset =
     assert (slot.pos = Unassigned);
     slot.pos <- Assigned offset;
+    List.iter (add_slot_offset_to_set offset slot) slot.sets;
     match slot.desc with
     | Closure c -> add_closure_offset env c offset
     | Env_var v -> add_env_var_offset env v offset

--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.ml
@@ -24,6 +24,11 @@ type env = {
 }
 (** Public state to store the mapping from elements of a closure to offset. *)
 
+let print_env fmt env =
+  Format.fprintf fmt "{@[<v>closures: @[<v>%a@]@,env_vars: @[<v>%a@]@]}"
+    (Closure_id.Map.print Numbers.Int.print) env.closure_offsets
+    (Var_within_closure.Map.print Numbers.Int.print) env.env_var_offsets
+
 let empty_env = {
   closure_offsets = Closure_id.Map.empty;
   env_var_offsets = Var_within_closure.Map.empty;
@@ -159,6 +164,19 @@ let layout env closures env_vars =
   let map = order env closures env_vars in
   layout_aux map [] 0
 
+let print_layout_slot fmt = function
+  | Env_var v -> Format.fprintf fmt "var %a" Var_within_closure.print v
+  | Infix_header -> Format.fprintf fmt "infix_header"
+  | Closure cid -> Format.fprintf fmt "closure %a" Closure_id.print cid
+
+let print_layout fmt l =
+  Format.fprintf fmt "@[<v>";
+  List.iter (fun (i, slot) ->
+      Format.fprintf fmt "@[<h>%d %a@]@," i print_layout_slot slot
+    ) l;
+  Format.fprintf fmt "@]"
+
+
 (* Greedy algorithm *)
 
 module Greedy = struct
@@ -236,8 +254,8 @@ module Greedy = struct
     sets_of_closures = [];
   }
 
-  (* printing *)
-(*
+  (*
+  (* debug printing *)
   let print_set_id fmt s = Format.fprintf fmt "%d" s.id
 
   let print_set_ids fmt l =
@@ -256,10 +274,14 @@ module Greedy = struct
         Format.fprintf fmt "%a,@ " print_slot_desc s
       ) l
 
+  let print_slot_pos fmt = function
+    | Assigned i -> Format.fprintf fmt "%d" i
+    | Unassigned -> Format.fprintf fmt "?"
+
   let print_slot fmt s =
     Format.fprintf fmt
-      "@[<hov>[pos: %d;@ size: %d;@ desc: %a;@ sets: %a]@]"
-      s.pos s.size print_desc s.desc print_set_ids s.sets
+      "@[<hov>[pos: %a;@ size: %d;@ desc: %a;@ sets: %a]@]"
+      print_slot_pos s.pos s.size print_desc s.desc print_set_ids s.sets
 
   let print_set fmt s =
     Format.fprintf fmt
@@ -277,10 +299,10 @@ module Greedy = struct
   let print fmt state =
     Format.fprintf fmt
       "@[<v 2>{ closures: @[<hov>%a@];@ env_vars: @[<hov>%a@];@ sets: @[<hov>%a@]@ }@]"
-      (Closure_id.Map.print print_slot_desc) state.closures
-      (Var_within_closure.Map.print print_slot_desc) state.env_vars
+      (Closure_id.Map.print print_slot) state.closures
+      (Var_within_closure.Map.print print_slot) state.env_vars
       print_sets state.sets_of_closures
-*)
+    *)
 
   (* Slots *)
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_closure.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_closure.mli
@@ -18,6 +18,9 @@ type env
 (** Type for accumulating information about offsets of
     closure ids and var within closures. *)
 
+val print_env : Format.formatter -> env -> unit
+(** Printing function for environment. *)
+
 val empty_env : env
 (** Empty environment. *)
 
@@ -66,4 +69,8 @@ val layout :
 (** Order the given closure ids and env vars into a list of layout slots
     together with their respective offset. Note that there may be holes
     between the offsets. *)
+
+val print_layout : Format.formatter -> layout -> unit
+val print_layout_slot : Format.formatter -> layout_slot -> unit
+(** Printing functions for layout slots and layouts. *)
 


### PR DESCRIPTION
Two bugfixes:

- the first was a difference in the name generated between `closure_name` and `closure_id_name` in `Un_cps_closure`. When I think about it, I don't see the point in having two distinct functions, maybe `closure_id_name` could be removed in favor of `closure_name`. I'll discuss it when @lthls returns from holidays
- a small bug in the computation of offsets for recursive functions, due to some missing code for correctly marking a slot as allocated.