### PR TITLE
Bugfixes

### DIFF
--- a/asmcomp/cmm_helpers.mli
+++ b/asmcomp/cmm_helpers.mli
@@ -551,7 +551,11 @@ val transl_int_switch :
   Location.t -> expression -> int -> int ->
   (int * expression) list -> expression -> expression
 
-(** [transl_switch_clambda loc arg index cases] *)
+(** [transl_switch_clambda loc arg index cases]
+    - [cases] is an array of expressions
+    - [index] is an index used to determine which case to take depending on the
+      value matched by [arg]. If [arg] is equal to [i], then [cases.(index.(i))]
+      will be executed. *)
 val transl_switch_clambda :
   Location.t -> expression -> int array -> expression array -> expression
 

--- a/middle_end/flambda2.0/language/basic/effects_and_coeffects.mli
+++ b/middle_end/flambda2.0/language/basic/effects_and_coeffects.mli
@@ -40,4 +40,6 @@ val commute : t -> t -> bool
     without changing their semantics. *)
 
 val has_commuting_effects : t -> bool
-(** Does the given effects and coeffects has observable effects ? *)
+(** Does the given effects and coeffects has observable effects ?
+    Rather, does it have some effects with regards to whether it can
+    commute with other expressions. *)

--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -963,6 +963,7 @@ and fill_slot decls elts env acc offset slot =
       end
 
 and fill_up_to j acc i =
+  assert (i <= j);
   if i = j then acc
   else fill_up_to j (C.int 1 :: acc) (i + 1)
 

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -166,6 +166,12 @@ let store ?(dbg=Debuginfo.none) kind init addr value =
 let extcall ?(dbg=Debuginfo.none) ?label ~alloc name typ_res args =
   Cmm.Cop (Cextcall (name, typ_res, alloc, label), args, dbg)
 
+(* unreachable/invalid expression *)
+
+let unreachable =
+  load Cmm.Word_int Asttypes.Mutable (int 0)
+
+
 (* Block creation *)
 
 let float_tag = function

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -40,6 +40,9 @@ val define_symbol : global:bool -> string -> Cmm.data_item list
 
 (** {2 Cmm values} *)
 
+val unreachable : Cmm.expression
+(** An invalid/dummy cmm expression that can be used for unreachable code. *)
+
 val void : Cmm.expression
 (** The void (i.e. empty tuple) cmm value. Not to be confused with [() : unit]. *)
 

--- a/seq.ml
+++ b/seq.ml
@@ -28,7 +28,7 @@ let return x () = Cons (x, empty)
 let rec map f seq () = match seq() with
   | Nil -> Nil
   | Cons (x, next) -> Cons (f x, map f next)
-(*
+
 let rec filter_map f seq () = match seq() with
   | Nil -> Nil
   | Cons (x, next) ->
@@ -71,4 +71,3 @@ let iter f seq =
         aux next
   in
   aux seq
-   *)

--- a/seq.ml
+++ b/seq.ml
@@ -28,7 +28,7 @@ let return x () = Cons (x, empty)
 let rec map f seq () = match seq() with
   | Nil -> Nil
   | Cons (x, next) -> Cons (f x, map f next)
-
+(*
 let rec filter_map f seq () = match seq() with
   | Nil -> Nil
   | Cons (x, next) ->
@@ -71,3 +71,4 @@ let iter f seq =
         aux next
   in
   aux seq
+   *)


### PR DESCRIPTION
Three bugfixes (as well as some more assertions):

- When translating a set of closures, the resulting env was ignored, causing some inlined let-bound variables to also be bound in the resulting cmm expression (not a safety bug, but the produced code contained unneeded let-bindings).
- Switches were previously miscompiled, they should now be correct.
- Closure offset computation had a bug where the first free offset after a slot was wrongly computed as the current offset + the slot size (instead of the slot starting pos + its size).

cc @lthls who might be interested in the comment I added to `cmm_helpers.ml` for the cmm_helper PR on trunk ?