### PR TITLE
Fix address computations for infix blocks

### DIFF
--- a/middle_end/flambda2.0/to_cmm/un_cps.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps.ml
@@ -456,7 +456,7 @@ let unary_primitive env dbg f arg =
       C.box_number ~dbg kind arg
   | Select_closure { move_from = c1; move_to = c2} ->
       let diff = (Env.closure_offset env c2) - (Env.closure_offset env c1) in
-      C.field_address arg diff dbg
+      C.infix_field_address ~dbg arg diff
   | Project_var v ->
       C.get_field_gen Asttypes.Immutable arg (Env.env_var_offset env v) dbg
 
@@ -626,9 +626,8 @@ and let_expr env t =
             Closure_id.Map.fold (fun cid v acc ->
                 let v = Var_in_binding_pos.var v in
                 let e =
-                  C.field_address soc_cmm_var
-                    (Env.closure_offset env cid)
-                    Debuginfo.none
+                  C.infix_field_address ~dbg: Debuginfo.none
+                    soc_cmm_var (Env.closure_offset env cid)
                 in
                 let_expr_bind body acc v e effs
               ) closure_vars env in

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -74,6 +74,16 @@ let targetint ?(dbg=Debuginfo.none) t =
   | Int32 i -> int32 ~dbg i
   | Int64 i -> int64 ~dbg i
 
+(* Infix field address.
+   Contrary to regular field addresse, these addresse are valid ocaml values,
+   and can be live at gc points. *)
+
+let infix_field_address ~dbg ptr n =
+  if n = 0 then
+    ptr
+  else
+    Cmm.Cop (Cmm.Caddv, [ptr; int ~dbg (n * Arch.size_addr)], dbg)
+
 (* Sequence *)
 
 let sequence x y =

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.mli
@@ -94,6 +94,13 @@ val box_int64 : ?dbg:Debuginfo.t -> Cmm.expression -> Cmm.expression
 
 (** {2 Block access} *)
 
+val infix_field_address :
+  dbg:Debuginfo.t -> Cmm.expression -> int -> Cmm.expression
+(** [infix_field_address ptr n dbg] returns an expression for the address
+    of the [n]-th field of the set of closures block pointed to by [ptr].
+    This function assumes that the [n-1]-th field of the block is an infix
+    header, so that the returned address is in fact a correct ocaml value. *)
+
 val block_length :
   ?dbg:Debuginfo.t -> Flambda_primitive.Block_access_kind.t ->
   Cmm.expression -> Cmm.expression


### PR DESCRIPTION
Previously computing the address of an infix block inside a set of closures would use a Cadda and thus produce Addr values, whereas they are actually of type Val, this fixes it.

This can also be applied to the flambda2.0 branch to fix the bad gc root bug.