### PR TITLE
Fix float.ml bug

### DIFF
--- a/.depend
+++ b/.depend
@@ -1928,10 +1928,12 @@ asmcomp/afl_instrument.cmi : \
     asmcomp/cmm.cmi
 asmcomp/arch.cmo : \
     utils/config.cmi \
-    utils/clflags.cmi
+    utils/clflags.cmi \
+    asmcomp/cmm.cmi
 asmcomp/arch.cmx : \
     utils/config.cmx \
-    utils/clflags.cmx
+    utils/clflags.cmx \
+    asmcomp/cmm.cmx
 asmcomp/asmgen.cmo : \
     lambda/translmod.cmi \
     asmcomp/split.cmi \

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -163,9 +163,6 @@ let infer_specific arg res = function
   | Isextend32 | Izextend32 ->
       [ `Bound (arg.(0), Cmm.Int);
         `Bound (res.(0), Cmm.Int) ]
-  | Izextend32 ->
-      [ `Bound (arg.(0), Cmm.Int);
-        `Bound (res.(0), Cmm.Int) ]
 
 let win64 =
   match Config.system with

--- a/asmcomp/amd64/arch.ml
+++ b/asmcomp/amd64/arch.ml
@@ -141,7 +141,6 @@ let print_specific_operation printreg op ppf arg =
 let infer_specific arg res = function
   | Ilea _ ->
       Array.fold_left (fun acc r ->
-          `Constraint (res.(0), r) ::
           `Bound (r, Cmm.Int) :: acc
         ) [] arg
   | Istore_int _ ->
@@ -161,7 +160,7 @@ let infer_specific arg res = function
   | Ifloatsqrtf _ ->
       [ `Bound (arg.(0), Cmm.Val);
         `Bound (res.(0), Cmm.Float) ]
-  | Isextend32 ->
+  | Isextend32 | Izextend32 ->
       [ `Bound (arg.(0), Cmm.Int);
         `Bound (res.(0), Cmm.Int) ]
   | Izextend32 ->

--- a/asmcomp/amd64/proc.ml
+++ b/asmcomp/amd64/proc.ml
@@ -168,7 +168,7 @@ let calling_conventions first_int last_int first_float last_float make_stack
     match arg.(i).typ with
     | Val | Int | Addr as ty ->
         if !int <= last_int then begin
-          loc.(i) <- phys_reg !int;
+          loc.(i) <- Reg.at_location ty (Reg !int);
           incr int
         end else begin
           loc.(i) <- stack_slot (make_stack !ofs) ty;
@@ -237,7 +237,7 @@ let win64_loc_external_arguments arg =
     match arg.(i).typ with
     | Val | Int | Addr as ty ->
         if !reg < 4 then begin
-          loc.(i) <- phys_reg win64_int_external_arguments.(!reg);
+          loc.(i) <- Reg.at_location ty (Reg win64_int_external_arguments.(!reg));
           incr reg
         end else begin
           loc.(i) <- stack_slot (Outgoing !ofs) ty;

--- a/asmcomp/asmgen.ml
+++ b/asmcomp/asmgen.ml
@@ -73,6 +73,8 @@ let compile_fundecl ~ppf_dump fd_cmm =
   fd_cmm
   ++ Profile.record ~accumulate:true "selection" Selection.fundecl
   ++ pass_dump_if ppf_dump dump_selection "After instruction selection"
+  ++ Profile.record ~accumulate:true "regtype" Regtype.fundecl
+(*++ pass_dump_if ppf_dump (ref false) "After register typing"*)
   ++ Profile.record ~accumulate:true "comballoc" Comballoc.fundecl
   ++ pass_dump_if ppf_dump dump_combine "After allocation combining"
   ++ Profile.record ~accumulate:true "cse" CSE.fundecl

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -61,6 +61,23 @@ let lub_component comp1 comp2 =
     (* Float unboxing code must be sure to avoid this case. *)
     assert false
 
+let glb_component comp1 comp2 =
+  match comp1, comp2 with
+  | Int, Int -> Int
+  | Int, Val -> Int
+  | Int, Addr -> Int
+  | Val, Int -> Int
+  | Val, Val -> Val
+  | Val, Addr -> Val
+  | Addr, Int -> Int
+  | Addr, Addr -> Addr
+  | Addr, Val -> Val
+  | Float, Float -> Float
+  | (Int | Addr | Val), Float
+  | Float, (Int | Addr | Val) ->
+    (* Float unboxing code must be sure to avoid this case. *)
+      assert false
+
 let ge_component comp1 comp2 =
   match comp1, comp2 with
   | Int, Int -> true

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -44,6 +44,10 @@ let typ_float = [|Float|]
   error will result.)
 *)
 
+exception Incompatible_types of machtype_component * machtype_component
+(** Raised by comparison and upper/lower bounds functions on machtype_components
+    to denote machtype_components that cannot be compared. *)
+
 let lub_component comp1 comp2 =
   match comp1, comp2 with
   | Int, Int -> Int
@@ -58,8 +62,8 @@ let lub_component comp1 comp2 =
   | Float, Float -> Float
   | (Int | Addr | Val), Float
   | Float, (Int | Addr | Val) ->
-    (* Float unboxing code must be sure to avoid this case. *)
-    assert false
+      (* Float unboxing code must be sure to avoid this case. *)
+      raise (Incompatible_types (comp1, comp2))
 
 let glb_component comp1 comp2 =
   match comp1, comp2 with
@@ -75,8 +79,8 @@ let glb_component comp1 comp2 =
   | Float, Float -> Float
   | (Int | Addr | Val), Float
   | Float, (Int | Addr | Val) ->
-    (* Float unboxing code must be sure to avoid this case. *)
-      assert false
+      (* Float unboxing code must be sure to avoid this case. *)
+      raise (Incompatible_types (comp1, comp2))
 
 let ge_component comp1 comp2 =
   match comp1, comp2 with
@@ -92,7 +96,7 @@ let ge_component comp1 comp2 =
   | Float, Float -> true
   | (Int | Addr | Val), Float
   | Float, (Int | Addr | Val) ->
-    assert false
+      raise (Incompatible_types (comp1, comp2))
 
 type integer_comparison = Lambda.integer_comparison =
   | Ceq | Cne | Clt | Cgt | Cle | Cge

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -55,20 +55,28 @@ val typ_addr: machtype
 val typ_int: machtype
 val typ_float: machtype
 
-(** Least upper bound of two [machtype_component]s. *)
+(** Exception raised by comparison and upper/lower bounds functions on
+    machtype_components to denote machtype_components that cannot be
+    compared, such as floats and integer components. *)
+exception Incompatible_types of machtype_component * machtype_component
+
+(** Least upper bound of two [machtype_component]s.
+    @raise Incompatible_types *)
 val lub_component
    : machtype_component
   -> machtype_component
   -> machtype_component
 
-(** Greatest lower bound of two [machtype_component]s. *)
+(** Greatest lower bound of two [machtype_component]s.
+    @raise Incompatible_types *)
 val glb_component
    : machtype_component
   -> machtype_component
   -> machtype_component
 
 (** Returns [true] iff the first supplied [machtype_component] is greater than
-    or equal to the second under the relation used by [lub_component]. *)
+    or equal to the second under the relation used by [lub_component].
+    @raise Incompatible_types *)
 val ge_component
    : machtype_component
   -> machtype_component

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -61,6 +61,12 @@ val lub_component
   -> machtype_component
   -> machtype_component
 
+(** Greatest lower bound of two [machtype_component]s. *)
+val glb_component
+   : machtype_component
+  -> machtype_component
+  -> machtype_component
+
 (** Returns [true] iff the first supplied [machtype_component] is greater than
     or equal to the second under the relation used by [lub_component]. *)
 val ge_component

--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -1721,7 +1721,7 @@ let cache_public_method meths tag cache dbg =
      dbg),
   Clet (
     VP.create tagged,
-      Cop(Cadda, [lsl_const (Cvar li) log2_size_addr dbg;
+      Cop(Caddi, [lsl_const (Cvar li) log2_size_addr dbg;
         cconst_int(1 - 3 * size_addr)], dbg),
     Csequence(Cop (Cstore (Word_int, Assignment), [cache; Cvar tagged], dbg),
               Cvar tagged)))))

--- a/asmcomp/regtype.ml
+++ b/asmcomp/regtype.ml
@@ -102,7 +102,7 @@ let rec set_lower_bound_aux env stack =
         else begin
           let typ = Cmm.lub_component r.typ bound in
           assert (typ <> r.typ);
-          Format.fprintf Format.err_formatter
+          Format.ifprintf Format.err_formatter
             "WARNING ! adjusted reg %a: %a -> %a@\n  because of %a@."
             Printmach.reg r Printcmm.machtype_component r.typ Printcmm.machtype_component typ
             print_reason reason;

--- a/asmcomp/regtype.ml
+++ b/asmcomp/regtype.ml
@@ -16,28 +16,72 @@ open Cmm
 open Reg
 open Mach
 
+
+(* Reasons for lower bounds on registers, can be either:
+   - a statically known lower-bound
+   - a constraint speciying a register should have a greater type
+     then another register *)
 type reason =
-  | Lower_bound of Cmm.machtype_component
+  | Lower_bound of Cmm.machtype_component * Mach.instruction
   | Constraint of Reg.t * Mach.instruction
 
 let print_reason fmt = function
-  | Lower_bound ty -> Format.fprintf fmt " > %a" Printcmm.machtype_component ty
-  | Constraint (r, i) -> Format.fprintf fmt " > %a || %a" Printmach.reg r Printmach.instr i
+  | Lower_bound (ty, i) ->
+      Format.fprintf fmt " > %a || %a"
+        Printcmm.machtype_component ty Printmach.instr i
+  | Constraint (r, i) ->
+      Format.fprintf fmt " > %a || %a"
+        Printmach.reg r Printmach.instr i
 
+(* Statically known upper bound on register types. These arise from stores, which
+   set a static upper bounds on the contents of a register. *)
+type upper_bound = {
+  ty : Cmm.machtype_component;
+  reasons : Mach.instruction list;
+}
+
+let print_upper_bound fmt { ty; reasons; } =
+  let pp_sep fmt () = Format.fprintf fmt "@ || " in
+  Format.fprintf fmt " <= %a @[<hv>|| %a@]"
+    Printcmm.machtype_component ty
+    (Format.pp_print_list ~pp_sep Printmach.instr) reasons
+
+
+(* Register typing environment.
+   The environment accumulates constraints on register types (lowetr and upper bounds).
+   The algorithm in this module assumes that most registers already have an adequate type,
+   and there will be only a few register type updates to perform (and even fewer cycles
+   of constraints). As such, the env registers constrinats between register types,
+   while static lower bounds trigger a walk of the constraint graph to upgrade the
+   registers' types as needed (which should be fairly quick and limited given the
+   assumptions above). Upper bounds on types are stored in the env and checked
+   once at the end. *)
 type environment = {
   constraints : reason Reg.Map.t Reg.Map.t;
   (* map a register [r] to a set of registers whose type needs to be greater
      or equal to that of [r] *)
+  upper_bounds : upper_bound Reg.Map.t;
 }
 
 let empty_env = {
   constraints = Reg.Map.empty;
+  upper_bounds = Reg.Map.empty;
 }
 
 let get_constraint env r =
   try Reg.Map.find r env.constraints
   with Not_found -> Reg.Map.empty
 
+let set_upper_bound env i r ty =
+  let instr = { i with next = end_instr (); } in
+  let b =
+    match Reg.Map.find r env.upper_bounds with
+    | exception Not_found -> { ty; reasons = [instr]; }
+    | b' ->
+        { ty = Cmm.glb_component ty b'.ty;
+          reasons = instr :: b'.reasons; }
+  in
+  { env with upper_bounds = Reg.Map.add r b env.upper_bounds; }
 
 (* enforce a constant constraint reg.typ >= b *)
 let rec set_lower_bound_aux env stack =
@@ -47,10 +91,10 @@ let rec set_lower_bound_aux env stack =
       else begin
         let typ = Cmm.lub_component r.typ bound in
         assert (typ <> r.typ);
-        Format.ifprintf Format.err_formatter
+        Format.fprintf Format.err_formatter
           "WARNING ! adjusted reg %a: %a -> %a@\n  because of %a@."
           Printmach.reg r Printcmm.machtype_component r.typ Printcmm.machtype_component typ
-        print_reason reason;
+          print_reason reason;
         r.typ <- typ;
         let s = get_constraint env r in
         Reg.Map.iter (fun r' reason -> Stack.push (r', reason, typ) stack) s;
@@ -59,16 +103,19 @@ let rec set_lower_bound_aux env stack =
   | exception Stack.Empty ->
       ()
 
-let set_lower_bound env reg b =
+let set_lower_bound env i reg b =
   let stack = Stack.create () in
-  Stack.push (reg, Lower_bound b, b) stack;
-  set_lower_bound_aux env stack
+  let instr = { i with next = end_instr () } in
+  Stack.push (reg, Lower_bound (b, instr), b) stack;
+  set_lower_bound_aux env stack;
+  env
 
-let set_lower_bounds env regs b =
+let set_lower_bounds env i regs b =
   let stack = Stack.create () in
-  Array.iter (fun r -> Stack.push (r, Lower_bound b, b) stack) regs;
-  set_lower_bound_aux env stack
-
+  let instr = { i with next = end_instr () } in
+  Array.iter (fun r -> Stack.push (r, Lower_bound (b, instr), b) stack) regs;
+  set_lower_bound_aux env stack;
+  env
 
 (* add a constraint specifying that r1.typ >= r2.typ *)
 let add_constraint env i r1 r2 =
@@ -76,83 +123,83 @@ let add_constraint env i r1 r2 =
   let reason = Constraint (r2, { i with next = end_instr ()}) in
   let s' = Reg.Map.add r1 reason s in
   let constraints = Reg.Map.add r2 s' env.constraints in
-  let env = { (* env with *) constraints } in
+  let env = { env with constraints } in
   let stack = Stack.create () in
   Stack.push (r1, reason, r2.typ) stack;
   set_lower_bound_aux env stack;
   env
 
-let add_constraints env i a1 a2 =
-  let cur = ref env in
-  Array.iter2 (fun r1 r2 -> cur := add_constraint !cur i r1 r2) a1 a2;
-  !cur
 
-
-let type_of_chunk = function
+let chunk_lower_type = function
   | Word_val -> Val
   | Single | Double | Double_u -> Float
   | _ -> Int
 
+let chunk_upper_type = function
+  | Single | Double | Double_u -> Float
+  | _ -> Val
+
 let specific env i arg res op =
   let aux acc = function
     | `Constraint (r1, r2) -> add_constraint acc i r1 r2
-    | `Bound (r, b) -> set_lower_bound acc r b; acc
+    | `Bound (r, b) -> set_lower_bound acc i r b
   in
   let l = Arch.infer_specific arg res op in
   List.fold_left aux env l
 
 let infer_op env i arg res = function
-  | Imove -> add_constraints env i res arg
+
+  | Imove -> add_constraint env i res.(0) arg.(0)
+  | Iconst_int _ -> set_lower_bound env i res.(0) Int
+  | Iconst_float _-> set_lower_bound env i res.(0) Float
+  | Iconst_symbol _ -> set_lower_bound env i res.(0) Val
+
   | Ispill
-  | Ireload -> assert false
-  | Iconst_int _ -> set_lower_bound env res.(0) Int; env
-  | Iconst_float _-> set_lower_bound env res.(0) Float; env
-  | Iconst_symbol _ -> set_lower_bound env res.(0) Val; env
+  | Ireload -> env
+  (* result registers types are already set during selectgen *)
   | Icall_ind _ | Icall_imm _
   | Itailcall_ind _ | Itailcall_imm _
-  | Iextcall _ ->
-      (* result registers types are already set during selectgen *)
-      env
+  | Iextcall _ -> env
   | Istackoffset _ -> env
-  | Iload (chunk, _) -> set_lower_bound env res.(0) (type_of_chunk chunk); env
-  | Istore (chunk, _, _) -> set_lower_bound env arg.(0) (type_of_chunk chunk); env
-  | Ialloc _ -> set_lower_bound env res.(0) Val; env
+
+  (* TODO: cover more exhaustively the various addressing modes to also
+           infer type for the address registers ? *)
+  | Iload (chunk, _) -> set_lower_bound env i res.(0) (chunk_lower_type chunk)
+  | Istore (chunk, _, _) -> set_upper_bound env i arg.(0) (chunk_upper_type chunk)
+  | Ialloc _ ->
+      (* CR Gbury: should we also set Val to be the upper bound on res.(0) ? *)
+      set_lower_bound env i res.(0) Val
+
+  (* Adequate register types have been set in selectegn based on the cmm operation
+     used (e.g. Caddi vs Cadda). *)
   | Iintop _
   | Iintop_imm _ ->
-      set_lower_bounds env arg Int;
-      begin match res with
-      | [| |] -> env
-      | [| r |] ->
-          Array.fold_left (fun acc r' -> add_constraint acc i r r') env arg
-      | _ -> assert false
-      end
+      let env = set_lower_bounds env i arg Int in
+      set_lower_bounds env i res Int
   | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf ->
-      set_lower_bounds env arg Float;
-      set_lower_bounds env res Float;
-      env
+      let env = set_lower_bounds env i arg Float in
+      set_lower_bounds env i res Float
   | Ifloatofint ->
-      set_lower_bound env arg.(0) Int;
-      set_lower_bound env res.(0) Float;
-      env
+      let env = set_lower_bound env i arg.(0) Int in
+      set_lower_bound env i res.(0) Float
   | Iintoffloat ->
-      set_lower_bound env arg.(0) Float;
-      set_lower_bound env res.(0) Int;
-      env
+      let env = set_lower_bound env i arg.(0) Float in
+      set_lower_bound env i res.(0) Int
   | Ispecific op -> specific env i arg res op
   | Iname_for_debugger _ -> env
 
-let test env arg _res = function
+let test env i arg _res = function
   | Itruetest | Ifalsetest -> env
   | Ioddtest | Ieventest
-  | Iinttest _ | Iinttest_imm _ -> set_lower_bounds env arg Int; env
-  | Ifloattest _ -> set_lower_bounds env arg Float; env
+  | Iinttest _ | Iinttest_imm _ -> set_lower_bounds env i arg Int
+  | Ifloattest _ -> set_lower_bounds env i arg Float
 
 let rec instruction_desc env i args res = function
   | Iend -> assert false
   | Iop op -> infer_op env i args res op
   | Ireturn -> env
   | Iifthenelse (t, then_branch, else_branch) ->
-      let env = test env args res t in
+      let env = test env i args res t in
       let env = instruction env then_branch in
       let env = instruction env else_branch in
       env
@@ -175,7 +222,16 @@ and instruction env i =
       let env' = instruction_desc env i i.arg i.res i.desc in
       instruction env' i.next
 
+let check_upper_bounds env =
+  Reg.Map.iter (fun r b ->
+      if not (Cmm.ge_component b.ty r.typ) then
+        Misc.fatal_errorf "Invalid register typ %a for %a@\n  because of %a"
+          Printcmm.machtype_component r.typ Printmach.reg r
+          print_upper_bound b
+    ) env.upper_bounds
+
 let fundecl decl =
   let env = empty_env in
-  let _ : environment = instruction env decl.fun_body in
+  let env = instruction env decl.fun_body in
+  let () = check_upper_bounds env in
   decl

--- a/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
+++ b/middle_end/flambda2.0/from_lambda/lambda_to_flambda_primitives.ml
@@ -478,7 +478,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     let field = Simple.const (Simple.Const.Tagged_immediate imm) in
     Ternary (Block_set (Block Naked_float,
         C.convert_init_or_assign init_or_assign),
-      block, Simple field, value)
+      block, Simple field, unbox_float value)
   | Pdivint Unsafe, [arg1; arg2] ->
     Binary (Int_arith (I.Tagged_immediate, Div), arg1, arg2)
   | Pdivint Safe, [arg1; arg2] ->
@@ -643,7 +643,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
       array, index, new_value)
   | Parraysetu Pfloatarray, [array; index; new_value] ->
     Ternary (Block_set (Array Naked_float, Assignment),
-      array, index, new_value)
+      array, index, unbox_float new_value)
   | Parraysets (Pgenarray | Paddrarray | Pintarray),
       [array; index; new_value] ->
     Checked {
@@ -664,7 +664,7 @@ let convert_lprim ~backend (prim : L.primitive) (args : Simple.t list)
     Checked {
       primitive =
         Ternary (Block_set (Array Naked_float, Assignment),
-          array, index, new_value);
+          array, index, unbox_float new_value);
       validity_conditions = [
         Binary (Int_comp (Tagged_immediate, Signed, Ge), index,
           Simple (Simple.const (Simple.Const.Tagged_immediate

--- a/middle_end/flambda2.0/terms/flambda_primitive.ml
+++ b/middle_end/flambda2.0/terms/flambda_primitive.ml
@@ -222,7 +222,6 @@ let array_like_thing_index_kind = K.value
 let bigarray_kind = K.value
 let bigstring_kind = K.value
 let block_kind = K.value
-let block_element_kind = K.value
 let string_or_bytes_kind = K.value
 
 type comparison = Eq | Neq | Lt | Gt | Le | Ge
@@ -938,8 +937,9 @@ let print_ternary_primitive ppf p =
 
 let args_kind_of_ternary_primitive p =
   match p with
-  | Block_set _ ->
-    block_kind, array_like_thing_index_kind, block_element_kind
+  | Block_set (block_access_kind, _) ->
+    block_kind, array_like_thing_index_kind,
+      Block_access_kind.element_kind block_access_kind
   | Bytes_or_bigstring_set (Bytes, (Eight | Sixteen)) ->
     string_or_bytes_kind, array_like_thing_index_kind,
       K.value

--- a/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
+++ b/middle_end/flambda2.0/to_cmm/un_cps_helper.ml
@@ -231,7 +231,7 @@ let block_load ?(dbg=Debuginfo.none) kind block index =
   match array_kind_of_block_access kind with
   | Lambda.Pintarray -> int_array_ref block index dbg
   | Lambda.Paddrarray -> addr_array_ref block index dbg
-  | Lambda.Pfloatarray -> float_array_ref block index dbg
+  | Lambda.Pfloatarray -> unboxed_float_array_ref block index dbg
   | Lambda.Pgenarray ->
       ite ~dbg (is_addr_array_ptr block dbg)
         ~then_:(addr_array_ref block index dbg) ~then_dbg:dbg
@@ -247,7 +247,7 @@ let block_set ?(dbg=Debuginfo.none) kind init block index value =
   | Pintarray ->
       return_unit dbg (int_array_set block index value dbg)
   | Pfloatarray ->
-      return_unit dbg (float_array_set block index (unbox_float dbg value) dbg)
+      return_unit dbg (float_array_set block index value dbg)
   | Paddrarray ->
       return_unit dbg (addr_array_store init block index value dbg)
   | Pgenarray ->


### PR DESCRIPTION
Three things in this PR:
- a more homogenous treatments of the kinds of `Bock_load` / `Block_set`: whenever theses primitives are known to operate on flat float arrays/blocks, they take (or return) a naked float instead of a caml value
- un_cps is adjusted to these kinds
- the register typing inference is updated to detect register mismatches (such as moves/reads/loads between integer and floats types) and print proper errors which will help pinpointing where in the cmm code the invalid code is (and thus better identify the un_cps fragment leading to the type mismatch).

The part dealing with flambda2 primitives probably needs to be reviewed to ensure I didn't make any mistake.